### PR TITLE
use PropTypes from reacts separated library

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-preset-react-native": "1.9.1",
     "jest": "18.1.0",
     "jest-react-native": "18.0.0",
+    "prop-types": "^15.6.0",
     "react-test-renderer": "~15.4.2"
   }
 }

--- a/src/Screen.js
+++ b/src/Screen.js
@@ -2,7 +2,8 @@
  * Author: Miguel Caballero
  */
 'use strict';
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {Platform, Dimensions, View, StyleSheet, ScrollView, Image, Text, TouchableWithoutFeedback} from 'react-native';
 
 const DEFAULT_STATUS_BAR_HEIGHT = (Platform.OS === 'ios') ? 20 : 0;


### PR DESCRIPTION
This stops warnings for this using React.PropTypes with React 16